### PR TITLE
Remove duplication of warnings

### DIFF
--- a/lib/rubbr/runner.rb
+++ b/lib/rubbr/runner.rb
@@ -45,7 +45,7 @@ module Rubbr
 
           run = `#@executable #@input_file`
           lines = run.split("\n")
-          @warnings = run.grep(messages).sort
+          @warnings = run.grep(messages).sort.uniq
 
           if Rubbr.options[:verboser]
 


### PR DESCRIPTION
Some warnings are repeated many times:

```
- Overfull \hbox (2.71146pt too wide) in paragraph at lines 427--427
- Overfull \hbox (2.71146pt too wide) in paragraph at lines 427--427
- Overfull \hbox (2.71146pt too wide) in paragraph at lines 427--427
- Overfull \hbox (2.71146pt too wide) in paragraph at lines 427--427
```

This patch fixes it.
